### PR TITLE
Allow to specify the IP address Turtl will listen on

### DIFF
--- a/config/config.yaml.default
+++ b/config/config.yaml.default
@@ -1,5 +1,8 @@
 ---
 server:
+  # Per default, turtl will listen on all IP addresses
+  # You can choose the IP it will use with this parameter
+  host:
   port: 8181
 
 db:

--- a/server.js
+++ b/server.js
@@ -57,6 +57,10 @@ plugin_list.forEach(function(plugin) {
 	loader.load(plugins.register.bind(plugins, plugin), plugin_config);
 });
 
-app.listen(config.server.port);
-log.info('Listening for turtls on port '+config.server.port+'...');
-
+if (config.server.host) {
+	app.listen(config.server.port, config.server.host);
+	log.info('Listening for turtls on IP '+config.server.host+', port '+config.server.port+'...');
+} else {
+	app.listen(config.server.port);
+	log.info('Listening for turtls on port '+config.server.port+'...');
+}


### PR DESCRIPTION
You may want to make Turtl listen on 127.0.0.1 in order to put it behind
a Nginx Proxy.