### PR TITLE
Fix ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,9 @@ jobs:
       # set up/run server
       - run: cp config/config.yaml.ci config/config.yaml
       - restore_cache:
-          key: server-npm-v1-{{ checksum "../server/package.json" }}
-          key: server-npm-v1-
+          keys:
+            - server-npm-v1-{{ checksum "../server/package.json" }}
+            - server-npm-v1-
       - run: npm install
       - save_cache:
           key: server-npm-v1-{{ checksum "../server/package.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ jobs:
     <<: *defaults
 
     docker:
-      - image: circleci/node:4.8.3
-      - image: circleci/postgres:9.6.2-alpine
+      - image: circleci/node:13.0.1
+      - image: circleci/postgres:12.0-alpine
         environment:
           - POSTGRES_USER=turtl
           - POSTGRES_DB=turtl


### PR DESCRIPTION
circleci/node:4.8.3 uses debian Jessie as a base which is now out of
commission.

Ok, I guess it's not possible for you to activate circleci for forks due to the number of secrets used in the CI run.

I then hit:
```
#!/bin/bash -eo pipefail
gpg --import build-tools/rust.gpg.pub

gpg: directory '/home/circleci/.gnupg' created
gpg: keybox '/home/circleci/.gnupg/pubring.kbx' created
gpg: can't open 'build-tools/rust.gpg.pub': No such file or directory
gpg: Total number processed: 0
Exited with code 2
```

Will check later...