### PR TITLE
Lock user account after login failures

### DIFF
--- a/config/config.yaml.ci
+++ b/config/config.yaml.ci
@@ -17,6 +17,11 @@ app:
   # no trailing slash
   api_url: 'http://127.0.0.1:8181'
   www_url: 'https://yourdomain.com'
+  login:
+    # Max failed login attemps. Set to -1 to disable
+    max_attemps: 5
+    # User locked for this duration in seconds
+    lock_duration: 60
   emails:
     admin: 'admin@turtlapp.com'
     info: 'Turtl <info@turtlapp.com>'
@@ -49,5 +54,3 @@ s3:
   bucket: ''
   endpoint: 'https://s3.amazonaws.com'
   pathstyle: false
-
-

--- a/config/config.yaml.default
+++ b/config/config.yaml.default
@@ -18,6 +18,11 @@ app:
   # no trailing slash
   api_url: 'http://api.yourdomain.com:8181'
   www_url: 'https://yourdomain.com'
+  login:
+    # Max failed login attemps. Set to -1 to disable
+    max_attemps: 5
+    # User locked for this duration in seconds
+    lock_duration: 60
   emails:
     admin: 'admin@turtlapp.com'
     info: 'Turtl <info@turtlapp.com>'
@@ -64,4 +69,3 @@ s3:
   bucket: ''
   endpoint: 'https://s3.amazonaws.com'
   pathstyle: false
-

--- a/config/config.yaml.docker
+++ b/config/config.yaml.docker
@@ -17,6 +17,11 @@ app:
   # no trailing slash
   api_url: 'http://127.0.0.1:8181'
   www_url: 'https://yourdomain.com'
+  login:
+    # Max failed login attemps. Set to -1 to disable
+    max_attemps: 5
+    # User locked for this duration in seconds
+    lock_duration: 60
   emails:
     admin: 'admin@turtlapp.com'
     info: 'Turtl <info@turtlapp.com>'

--- a/tools/create-db-schema.js
+++ b/tools/create-db-schema.js
@@ -50,6 +50,8 @@ const builder = {
 	},
 	not_null: function(type) { return type+' not null'; },
 
+  default: function(type, df) { return type+' default '+df; },
+
 	table: function(table_name, options) {
 		var fields = options.fields;
 		var table_indexes = options.indexes;
@@ -215,6 +217,8 @@ builder.table('users', {
 		confirmation_token: ty.text,
 		data: ty.json,
 		last_login: ty.date,
+    login_failed_last: ty.date,
+    login_failed_count: builder.default(ty.int, 0),
 	},
 	indexes: [
 		{name: 'username', fields: ['username'], unique: true},
@@ -257,4 +261,3 @@ function run() {
 }
 
 run();
-


### PR DESCRIPTION
Hi ! 
Thank you for your great job ! 

I've just added the ability to lock the login of a user after N failed login attemps for N seconds
This can be configured : 

```yaml
app:
  login:
    # Max failed login attemps. Set to -1 to disable
    max_attemps: 5
    # User locked for this duration in seconds
    lock_duration: 60
```

I've added two fields to the table "user". Not sure if there is a database migration process.

```js
login_failed_last: ty.date,
login_failed_count: builder.default(ty.int, 0),
```

Regards, 

Marc