### PR TITLE
User registration plugin

### DIFF
--- a/example-plugins/user/main.js
+++ b/example-plugins/user/main.js
@@ -1,0 +1,85 @@
+const Promise = require('bluebird');
+const db = require('/app/helpers/db');
+const error = require('/app/helpers/error');
+const email_model = require('/app/models/email');
+const user_model = require('/app/models/user');
+const config = require('/app/helpers/config');
+
+exports.load = function(register, plugin_config) {
+	register({
+		insert: insert,
+		confirm_user: confirm_user,
+	});
+};
+
+/**
+ * Here you can build your own logic when a user registers
+ * In my case, registration needs to be validated by the admin
+ * When implementing the plugin, YOU have to insert the user in the database
+ */
+function insert(userrecord) {
+  // Build the e-mail
+	var subject = 'New Registration';
+	var body = [
+		'Please validate this new account : '+userrecord.username,
+		'',
+		user_model.get_confirm_url(userrecord),
+		'',
+		'Thanks!',
+		'- Turtl team',
+	].join('\n');
+
+	// Insert the inactive user in the database
+	userrecord.active = false;
+  db.insert('users', userrecord);
+
+	// Send the e-mail to the admin
+	email_model.send(config.app.emails.info, config.app.emails.admin, subject, body)
+	.catch(function(err) {
+		throw error.internal('problem sending confirmation email: '+err.message);
+	});
+
+	// Throw an error to prevent the client to login with the inactive account
+	// The standard confirm e-mail (See models/user.js > send_confirmation_email) will not be send
+	throw error.forbidden('Open Registration is disabled. Your account needs to be validated');
+}
+
+
+/**
+ * Here you can build your own logic when the confirmation URL is called
+ * You have to keep the logic of the original method user_model.confirm_user
+ * In my case,  will activate the user in the database and send him a confirmation e-mail
+ * The redirect after the action are keeped untouched (See controllers/users.js > confirm_user)
+ */
+function confirm_user(email, token) {
+	return user_model.get_by_email(email, {raw: true})
+		.then(function(user) {
+      // Here I skipped all error messages
+			// I don't want the usernames to be crawled this way
+			if(user) {
+				var server_token = user.confirmation_token;
+				if(server_token && user_model.secure_compare(token, server_token)) {
+					// Send the e-mail
+					var subject = 'Turtl - Your account is now active';
+					var body = [
+				    'Your account is now active. You can use it now.',
+						'',
+						'Username : '+user.username,
+						'',
+						'Thanks!',
+						'- Turtl team',
+					].join('\n');
+
+					email_model.send(config.app.emails.info, user.username, subject, body)
+					.catch(function(err) {
+						throw error.internal('problem sending confirmation email: '+err.message);
+					});
+
+					// Update the user in the database
+					return db.update('users', user.id, {confirmed: true, active: true, confirmation_token: null});
+				}
+			}
+			throw error.bad_request('Bad request');
+		})
+		.then(user_model.clean_user);
+}

--- a/models/user.js
+++ b/models/user.js
@@ -2,6 +2,7 @@
 
 var db = require('../helpers/db');
 var config = require('../helpers/config');
+var plugins = require('../helpers/plugins');
 var Promise = require('bluebird');
 var error = require('../helpers/error');
 var vlad = require('../helpers/validator');
@@ -73,6 +74,7 @@ var clean_user = function(user) {
 	delete user.auth;
 	return user;
 };
+exports.clean_user = clean_user;
 
 var auth_hash = function(authkey) {
 	// two iterations. yes, two. if someone gets the database, they
@@ -122,7 +124,7 @@ exports.join = function(userdata) {
 		.then(function(existing) {
 			if(existing) throw error.forbidden('the account "'+userdata.username+'" already exists');
 			var auth = auth_hash(userdata.auth);
-			return db.insert('users', {
+			var userrecord = {
 				username: userdata.username,
 				auth: auth,
 				active: true,
@@ -130,6 +132,12 @@ exports.join = function(userdata) {
 				confirmation_token: token,
 				data: db.json(data),
 				last_login: db.literal('now()'),
+			};
+
+			return plugins.with('user', function(user_plugin) {
+				return user_plugin.insert(userrecord);
+			}, function() {
+				  return db.insert('users', userrecord);
 			});
 		})
 		.tap(function(user) {
@@ -149,7 +157,7 @@ exports.join = function(userdata) {
 
 var send_confirmation_email = function(user) {
 	var subject = 'Welcome to Turtl! Please confirm your email';
-	var confirmation_url = config.app.api_url+'/users/confirm/'+encodeURIComponent(user.username)+'/'+encodeURIComponent(user.confirmation_token);
+	var confirmation_url = exports.get_confirm_url(user);
 	var body = [
 		'Welcome to Turtl! Your account is active and you\'re ready to start using the app.',
 		'',
@@ -168,26 +176,34 @@ var send_confirmation_email = function(user) {
 		});
 };
 
+exports.get_confirm_url = function(user) {
+	return config.app.api_url+'/users/confirm/'+encodeURIComponent(user.username)+'/'+encodeURIComponent(user.confirmation_token);
+};
+
 exports.confirm_user = function(email, token) {
-	return exports.get_by_email(email, {raw: true})
-		.then(function(user) {
-			if(!user) throw error.not_found('that email isn\'t attached to an active account');
-			if(user.confirmed) throw error.conflict('that account has already been confirmed');
-			var server_token = user.confirmation_token;
-			if(!server_token) throw error.internal('that account has no confirmation token');
-			if(!secure_compare(token, server_token)) throw error.bad_request('invalid confirmation token');
-			return db.update('users', user.id, {confirmed: true, confirmation_token: null});
-		})
-		.tap(function(user) {
-			return sync_model.add_record([user.id], user.id, 'user', user.id, 'edit');
-		})
-		.tap(function(user) {
-			// if thre are pending invites sent to the email that was just
-			// confirmed, we create invite.add sync records for them so the user
-			// sees them in their profile.
-			return invite_model.create_sync_records_for_email(user.id, email);
-		})
-		.then(clean_user);
+	return plugins.with('user', function(user_plugin) {
+		return user_plugin.confirm_user(email, token);
+	}, function() {
+		return exports.get_by_email(email, {raw: true})
+			.then(function(user) {
+				if(!user) throw error.not_found('that email isn\'t attached to an active account');
+				if(user.confirmed) throw error.conflict('that account has already been confirmed');
+				var server_token = user.confirmation_token;
+				if(!server_token) throw error.internal('that account has no confirmation token');
+				if(!secure_compare(token, server_token)) throw error.bad_request('invalid confirmation token');
+				return db.update('users', user.id, {confirmed: true, confirmation_token: null});
+			})
+			.tap(function(user) {
+				return sync_model.add_record([user.id], user.id, 'user', user.id, 'edit');
+			})
+			.tap(function(user) {
+				// if thre are pending invites sent to the email that was just
+				// confirmed, we create invite.add sync records for them so the user
+				// sees them in their profile.
+				return invite_model.create_sync_records_for_email(user.id, email);
+			})
+			.then(clean_user);
+	});
 };
 
 exports.resend_confirmation = function(user_id) {


### PR DESCRIPTION
Responding to the following feature request : 
https://github.com/turtl/tracker/issues/250

I have added two hooks to the user registration process.

The first one is called when the user joins and requires you to insert the user in the database. Allows you to append your own logic before the user is persisted (send e-mails, etc.)

The second one allows you to override the behaviour of the user.confirm_user function.

I've provided a sample plugin that enables the account validation by an admin.

Regards

Marc