### PR TITLE
Add options in docker config

### DIFF
--- a/config/config.yaml.docker
+++ b/config/config.yaml.docker
@@ -1,5 +1,6 @@
 ---
 server:
+  host:
   port: 8181
 
 db:
@@ -40,6 +41,8 @@ plugins:
     enabled: false
   email:
     enabled: false
+    endpoint:
+    defaults: {}
   premium:
     enabled: false
 


### PR DESCRIPTION
Because yaml_env only checks existing entries for environment variables you can't use them to override options not in the config file. For example email will not work out of the box as it will never read your endpoint. Adding host as an optional override as well